### PR TITLE
Close a connection with pending requests

### DIFF
--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -340,6 +340,10 @@ class ConnectionsPool(AbcPool):
                 logger.warning(
                     "Connection %r is in subscribe mode, closing it.", conn)
                 conn.close()
+            elif conn._waiters:
+                logger.warning(
+                    "Connection %r has pending commands, closing it.", conn)
+                conn.close()
             elif conn.db == self.db:
                 if self.maxsize and self.freesize < self.maxsize:
                     self._pool.append(conn)


### PR DESCRIPTION
A redis connection cannot return to a pool if it has pending requests, especially commands like "BLPOP/BRPOP". The command may block for an indefinite time, and stops the following commands from executing if the connection is acquired from the pool. Also, because the command is still executing, the BRPOP command may pop an item and drop it which creates bugs which are very hard to debug.